### PR TITLE
fix(wry): Guard Windows-only controller() call (Linux build fix)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2117,9 +2117,12 @@ async fn print_tab(app: tauri::AppHandle, id: String) -> Result<(), String> {
 async fn toggle_devtools(app: tauri::AppHandle, id: String) -> Result<(), String> {
     if let Some(wv) = app.get_webview(&id) {
         wv.with_webview(|webview| {
-            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
-                if let Ok(core) = webview.controller().CoreWebView2() {
-                    let _ = core.OpenDevToolsWindow();
+            let _ = catch_unwind(AssertUnwindSafe(|| {
+                #[cfg(windows)]
+                unsafe {
+                    if let Ok(core) = webview.controller().CoreWebView2() {
+                        let _ = core.OpenDevToolsWindow();
+                    }
                 }
             }));
         }).map_err(|e| e.to_string())?;


### PR DESCRIPTION
- Problem: Linux build fails with E0599 because controller() is Windows-only.
- Change: Wrap the controller() / CoreWebView2() call in cfg(windows) and use catch_unwind(AssertUnwindSafe(...)).
- Verification: Ran cargo build locally (dev profile) in src-tauri — build completes.

Notes: This is a no-behavior change on Windows; only prevents Linux compile error, could squash/merge as a single commit.